### PR TITLE
Cast device.id as a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class LightifyPlatform {
     let self = this;
     self.getDevices().then((devices) => {
       let accessories = _.map(devices, (device) => {
-        device.name = device.name || device.id;
+        device.name = device.name || `${device.id}`;
         if (lightify.isPlug(device.type)) {
           return new LightifyPlug(device.name, UUIDGen.generate(device.name), device, device.mac, self.getLightify(), self);
         } else if (lightify.isLight(device.type)) {


### PR DESCRIPTION
UUIDGen fails if supplied a number, cast device.id as a string to fix