### PR TITLE
changed lookup from name to mac

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ class LightifyPlug {
     let self = this;
     this.platform.getDevices().then((data) => {
       let device = _.findWhere(data, {
-        "name": self.name
+        "mac": self.mac
       });
       self.update.bind(self)(device);
       callback(null, device.online && device.status);


### PR DESCRIPTION
Name might be missing (this is true for IKEA Trådlös devices) or even
not unique (?), lookup on Mac seems a lot safer...